### PR TITLE
fix: 좋아요 에러 수정

### DIFF
--- a/src/routes/isLike/isLike.router.js
+++ b/src/routes/isLike/isLike.router.js
@@ -24,7 +24,7 @@ router.post("/posts/:postId/like", authMiddleware, async (req, res, next) => {
 
     if (!like) {
       await prisma.posts.update({
-        where: { postId: +postId, UserId: +userId },
+        where: { postId: +postId },
         data: { likeCount: { increment: 1 } }
       })
 


### PR DESCRIPTION
좋아요 ` record to update not found` 에러 수정완료했습니다.
posts를 업데이트하는 쿼리에 where조건을 잘 못 넣어서 발생했습니다.